### PR TITLE
remove cockroach zone configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,9 +86,6 @@ func initConfig() {
 	viper.SetDefault("DB.Cockroach.Port", 26257)
 	viper.SetDefault("DB.Cockroach.Username", "root")
 	viper.SetDefault("DB.Cockroach.Database", "scoretrak")
-	viper.SetDefault("DB.Cockroach.ConfigureZones", true)
-	viper.SetDefault("DB.Cockroach.DefaultZoneConfig.GcTtlseconds", 600)
-	viper.SetDefault("DB.Cockroach.DefaultZoneConfig.BackpressueRangeSizeMultiplier", 0)
 
 	// Queue Defaults
 	viper.SetDefault("Queue.Use", "none")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -3,8 +3,6 @@ package storage
 import (
 	"errors"
 	"fmt"
-	"log"
-
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
@@ -48,8 +46,6 @@ func NewDB(c Config) (*gorm.DB, error) {
 var ErrIncompleteCertInformationProvided = errors.New("you provided some, but not all certificate information")
 
 // newCockroach is internal method used for initializing cockroach db instance.
-// It modifies few cockroachdb options like kv.range.backpressure_range_size_multiplier and gc.ttlseconds that
-// allows for a single large value to be changed frequently
 func newCockroach(c Config) (*gorm.DB, error) {
 	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s dbname=%s",
 		c.Cockroach.Host,
@@ -78,18 +74,6 @@ func newCockroach(c Config) (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	if c.Cockroach.ConfigureZones {
-		err := db.Exec("ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = ?;", c.Cockroach.DefaultZoneConfig.GcTtlseconds).Error
-		if err != nil {
-			return nil, err
-		}
-		err = db.Exec("SET CLUSTER SETTING kv.range.backpressure_range_size_multiplier= ?;", c.Cockroach.DefaultZoneConfig.BackpressureRangeSizeMultiplier).Error
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		log.Println("You have chosen not to allow master configure database zones. Make sure you set gc.ttlseconds to something below 1200, so that report generation is not affected")
-	}
 	return db, nil
 }
 
@@ -97,18 +81,13 @@ type Config struct {
 	Use       string `default:"cockroach"`
 	Prefix    string `default:""`
 	Cockroach struct {
-		Host              string `default:"cockroach"`
-		Port              string `default:"26257"`
-		UserName          string `default:"root"`
-		Password          string `default:""`
-		ClientCA          string `default:""`
-		ClientSSLKey      string `default:""`
-		ClientSSLCert     string `default:""`
-		Database          string `default:"scoretrak"`
-		ConfigureZones    bool   `default:"true"`
-		DefaultZoneConfig struct {
-			GcTtlseconds                    uint64 `default:"600"`
-			BackpressureRangeSizeMultiplier uint64 `default:"0"`
-		}
+		Host          string `default:"cockroach"`
+		Port          string `default:"26257"`
+		UserName      string `default:"root"`
+		Password      string `default:""`
+		ClientCA      string `default:""`
+		ClientSSLKey  string `default:""`
+		ClientSSLCert string `default:""`
+		Database      string `default:"scoretrak"`
 	}
 }


### PR DESCRIPTION
Removed the cockroach database configuration and automate it in the helm-charts repo (https://github.com/ScoreTrak/helm-charts/pull/21).
