### PR TITLE
replace golang alpine with alpine.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go build -o scoretrak -ldflags "-X 'github.com/ScoreTrak/ScoreTrak/pkg/versi
 RUN chmod +x scoretrak
 
 
-FROM golang:1.17-alpine
+FROM alpine:3.15
 
 COPY --from=builder \
     /go/src/github.com/ScoreTrak/ScoreTrak/scoretrak \


### PR DESCRIPTION
Since we are only running a binary generated in the build stage, there is no need to use the golang-alpine image. alpine image will suffice.